### PR TITLE
bugfix for empty gray class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ bower install --save gray
 Changelog
 ---------
 
+* v1.3.1: bugfix for empty gray class name
 * v1.3.0: rename fade class to grayscale-fade to resolve conflict with bootstrap
 * v1.2.0: IE shim: Copy styles from element to replacement element
 * v1.1.1: Improve documentation and demo

--- a/js/jquery.gray.js
+++ b/js/jquery.gray.js
@@ -16,8 +16,8 @@
   function Plugin (element, options) {
     options = options || {};
 
-    options.classes = options.classes || {};
-    fadeClass = options.classes.fade || defaults.classes.fade;
+    classes = options.classes || {};
+    fadeClass = classes.fade || defaults.classes.fade;
     options.fade = options.fade || element.className.indexOf(fadeClass) > -1;
 
     this.element = element;


### PR DESCRIPTION
Don't set options.classes to an empty array if it doesn't exist.
