### PR TITLE
Allow background-position to be a single property

### DIFF
--- a/js/jquery.gray.js
+++ b/js/jquery.gray.js
@@ -98,7 +98,8 @@
           margin;
 
       x = backgroundPosition.match(/^(-?\d+\S+)/)[0];
-      y = backgroundPosition.match(/\s(-?\d+\S+)$/)[0];
+      y = backgroundPosition.match(/\s(-?\d+\S+)$/);
+      y = y ? y[0] : x; // Allow a single background-position property
 
       margin = 'margin:' + y + ' 0 0 ' + x;
 


### PR DESCRIPTION
This fixes a fatal error if an image has a `background-position` like:

``` css
div {
  background-position: 50%;
}
```
